### PR TITLE
하트비트, 로그를 갱신하는 디스코드 백앤드 서버 API에 대응하는 로직 추가

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,3 @@
+[Common]
+configLogUrl='https://path/to/heartbeat/endpoint'
+LogUrl='https://path/to/log/endpoint'

--- a/metricUpload.py
+++ b/metricUpload.py
@@ -1,0 +1,44 @@
+import configparser
+from httplib2 import Http
+from urllib.parse import urlencode
+
+configExist = False
+configHeartbeatUrl = ''
+configLogUrl = ''
+
+
+def parseConfigure():
+    global configExist, configHeartbeatUrl, configLogUrl
+
+    config = configparser.ConfigParser()
+    config.read('config.ini')
+    if not 'Common' in config:
+        configExist = False
+    else:
+        configHeartbeatUrl = config['Common'].get('configLogUrl', '')
+        configLogUrl = config['Common'].get('LogUrl', '')
+        if configLogUrl == '' or configHeartbeatUrl == '':
+            configExist = False
+        else:
+            configExist = True
+            print("log url={0}, hb url={1}".format(configLogUrl, configHeartbeatUrl))
+    print("config exist: {0}".format(configExist))
+    return
+
+
+def uploadHeartbeat():
+    h = Http()
+    if not configExist:
+        return
+    h.request(configHeartbeatUrl, "GET")
+    print("heartbeat sent to {0}".format(configHeartbeatUrl))
+    return
+
+def uploadErrorLog(level, str):
+    h = Http()
+    if not configExist:
+        return
+    data = {'level': level, 'data': str}
+    h.request(configLogUrl, "POST", urlencode(data))
+    print("log sent to {0}".format(configLogUrl))
+    return

--- a/readGyro.py
+++ b/readGyro.py
@@ -6,6 +6,8 @@ import numpy as np
 import math
 import time
 import header
+import metricUpload
+import sys
 
 OPEN = 1
 CLOSE = 0
@@ -84,11 +86,19 @@ def git_function(barami_status):
         #     print("Some error occured while pushing the code")
 
 
+def globalExceptionHandler(exctype, value, traceback):
+    metricUpload.configLogUrl('error', "type: {0}, value: {1}, trace: {2}".format(exctype, value, traceback))
+
+
 if __name__ == "__main__":
+    sys.excepthook = globalExceptionHandler
     check = 0
     mag_list = list()
+    metricUpload.parseConfigure()
+    metricUpload.configLogUrl('info', "start application loop")
 
     while True:
+        metricUpload.uploadHeartbeat()
         mpu9250 = header.MPU9250()
         mag = mpu9250.readMagnet()
         mag_total = math.sqrt(mag['x']**2+mag['y']**2+mag['z']**2)
@@ -108,6 +118,6 @@ if __name__ == "__main__":
                 # print("open")
                 pushToGit(OPEN)
 
-            del(mag_list)
+            del (mag_list)
             mag_list = list()
             check = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+httplib2
+gitpython


### PR DESCRIPTION
## 변경점
![pr diagram](https://user-images.githubusercontent.com/22298073/190862296-9b1b14a5-147b-42b3-bd92-4a48a672479a.png)

본 MR은 기존의 진원쿤 디스코드 백앤드 서버와 바라미실은 열렸는가 라즈베리파이 서버 간의 양방향 연결 없이 중개 깃 저장소로만 상호작용하므로 원격에서 상태 또는 로그를 확인할 수 없었던 점을 개선하기 위함임.

추가되는 로직은 아래와 같음.
- 스크립트 시작 시 config.ini 파일을 읽어 디스코드 백앤드 서버의 주소를 읽어들임
- 어플리케이션의 매 센서 읽기 주기마다 (현재 1초) 디스코드 백앤드 서버에 하트비트 HTTP PUT 요청을 전송함
- 파이썬 런타임의 전역 예외 처리기에 디스코드 백앤드 서버에 오류 로그 HTTP PUT 요청을 전송하는 로직을 추가

결과적으로 디스코드에서 아래와 같이 최종 생존 시간 (하트비트) 및 로그를 확인 가능
![example](https://user-images.githubusercontent.com/22298073/190862482-76b41c05-50dd-4ad5-a6a1-b79cc92ceddc.png)

누적되는 로그와 하트비트 기록은 디스코드 백앤드 서버에 기록되며 요청의 주체 식별은 IP를 기준으로 함

## 운영 상 영향
- 디스코드 백앤드 서버인 jinwonbot의 1.3.x 상위 버전부터 호환됨 (https://github.com/Dictor/jinwonbot/releases/tag/v1.3.3)

## 테스팅
- 라즈베리파이가 없어 테스트 해보지 못함 (smbus)
- mockup을 통한 테스트 로직 추후 구현 필요
- 본 MR에서 추가되는 코드로 발생하는 오류나 예외는 어플리케이션 동작에 영향을 끼치지 않으므로 모두 무시되야 하나 이 부분에 대한 테스트 진행되지 않음